### PR TITLE
Fixes for uninitialized thread-local SITE_ID

### DIFF
--- a/domains/hooks/site_id.py
+++ b/domains/hooks/site_id.py
@@ -79,7 +79,7 @@ class SiteIDHook(IntHookBase):
         if DEFAULT_SITE_ID:
             site = get_site_by_host(DEFAULT_SITE_ID, field='pk')
             if site:
-                self.cache(host, site.pk)
+                self.set_and_cache(host, site.pk)
                 return
 
         if ALLOW_FALLBACK:

--- a/domains/hooks/site_id.py
+++ b/domains/hooks/site_id.py
@@ -10,6 +10,7 @@ from django.db.models.loading import get_model
 from domains.hooks.base import IntHookBase
 
 
+ALLOW_FALLBACK = getattr(settings, 'DOMAINS_ALLOW_FALLBACK', False)
 DEFAULT_SITE_ID = getattr(settings, 'DOMAINS_DEFAULT_SITE_ID', 0)
 HOST_CACHE = {}
 
@@ -81,9 +82,10 @@ class SiteIDHook(IntHookBase):
                 self.cache(host, site.pk)
                 return
 
-        try:  # misconfigured settings?
-            site = get_site_model().objects.all()[0]
-            self.set_and_cache(host, site.pk)
-            return
-        except IndexError:  # no sites in db
-            pass
+        if ALLOW_FALLBACK:
+            try:  # misconfigured settings?
+                site = get_site_model().objects.all()[0]
+                self.set_and_cache(host, site.pk)
+                return
+            except IndexError:  # no sites in db
+                pass

--- a/domains/hooks/site_id.py
+++ b/domains/hooks/site_id.py
@@ -74,10 +74,12 @@ class SiteIDHook(IntHookBase):
             if site:
                 self.set_and_cache(host, site.pk)
                 return
-        site = get_site_by_host(settings.SITE_ID, field='pk')
-        if site:
-            self.cache(host, site.pk)
-            return
+
+        if DEFAULT_SITE_ID:
+            site = get_site_by_host(DEFAULT_SITE_ID, field='pk')
+            if site:
+                self.cache(host, site.pk)
+                return
 
         try:  # misconfigured settings?
             site = get_site_model().objects.all()[0]

--- a/domains/hooks/site_id.py
+++ b/domains/hooks/site_id.py
@@ -10,6 +10,7 @@ from django.db.models.loading import get_model
 from domains.hooks.base import IntHookBase
 
 
+DEFAULT_SITE_ID = getattr(settings, 'DOMAINS_DEFAULT_SITE_ID', 0)
 HOST_CACHE = {}
 
 
@@ -55,6 +56,9 @@ class SiteIDHook(IntHookBase):
             return
         host = request.get_host()
         shost = host.rsplit(':', 1)[0]  # just host, no port
+
+        # Initialize with default value to reset the thread-local variable
+        self.set(DEFAULT_SITE_ID)
 
         if host in HOST_CACHE:
             self.set(HOST_CACHE[host])


### PR DESCRIPTION
This fixes a problem with the thread-local **SITE_ID** variable being unmodified in some cases.
I've had issues with requests switching between the Site instances at seemingly random, by ensuring that the **SITE_ID** is always properly initialized we avoid this problem.

In addition I disabled the fallback code that picks the first **Site** item, picking a random site is not what you normally want.
I used a setting for it so it can be brought back if wanted.
